### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Learn how to make a multiplayer first-person shooter in Unity. This series teach
 
 Watch the videos [HERE](https://www.youtube.com/playlist?list=PLPV2KyIb3jR5PhGqsO7G4PsbEC_Al-kPZ).
 
-###Software
+### Software
 - This project runs on the [Unity](http://unity3d.com) engine. Make sure to have the newest version installed before running the project. The project folder is called "MultiplayerFPS".
 
-###Copyright
+### Copyright
 This project is released into the public domain. For more information see LICENSE.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
