### PR TITLE
Fixing error message

### DIFF
--- a/MultiplayerFPS/Assets/Scripts/CameraFacingBillboard.cs
+++ b/MultiplayerFPS/Assets/Scripts/CameraFacingBillboard.cs
@@ -6,9 +6,11 @@ public class CameraFacingBillboard : MonoBehaviour {
 	// Update is called once per frame
 	void Update () {
 		Camera cam = Camera.main;
-
+		if(cam!=null)
+		{
 		transform.LookAt(transform.position + cam.transform.rotation * Vector3.forward,
 			cam.transform.rotation * Vector3.up);
+		}
 	}
 
 }


### PR DESCRIPTION
This fix error message "Object reference not set to an instance of an object", it used to happen when player re spawn.
The problem is most likely that Camera.main is not initialized (this commonly happens).